### PR TITLE
add support for object as metric

### DIFF
--- a/pkg/k8sresourcemetrics/k8s_resource_collector.go
+++ b/pkg/k8sresourcemetrics/k8s_resource_collector.go
@@ -107,7 +107,7 @@ func (k *kMetrics) Update() error {
 			u := unstructured.UnstructuredList{}
 			u.SetGroupVersionKind(v)
 
-			err = cl.List(context.Background(), &u, &client.ListOptions{Namespace: "", FieldSelector: val.FieldSelector, LabelSelector: val.LabelSelector})
+			err = cl.List(context.Background(), &u, &client.ListOptions{Namespace: val.Namespace, FieldSelector: val.FieldSelector, LabelSelector: val.LabelSelector})
 			if err != nil {
 				log.Error(err.Error())
 				continue

--- a/pkg/k8sresourcemetrics/k8s_resource_collector.go
+++ b/pkg/k8sresourcemetrics/k8s_resource_collector.go
@@ -2,18 +2,24 @@ package k8sresmetric
 
 import (
 	"context"
-	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spyzhov/ajson"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MetricsInfo struct {
-	Data []*ajson.Node
-	Path string
-	Obj  string
+	Data          []*ajson.Node
+	Path          string
+	Obj           string
+	FieldSelector fields.Selector
+	LabelSelector labels.Selector
+	Namespace     string
+	Iterator      string
 	// Separate out Label keys and path
 	// so that we do not have to iterate over map
 	// and risk being inconsistent with key and values.
@@ -26,16 +32,56 @@ type kMetrics struct {
 }
 
 func (k *kMetrics) RegisterMetric(m MetricsConfig) error {
+	var err error
 	k.metricsMap[m.Name] = &MetricsInfo{
 		Obj:       m.Properties.Object,
 		Path:      m.Properties.Value,
+		Namespace: m.Properties.Namespace,
 		LabelKeys: []string{},
 		Data:      []*ajson.Node{},
 	}
 
+	isKeyPresent := false
 	for key, path := range m.Properties.Labels {
+		if strings.HasPrefix(path, "key") {
+			isKeyPresent = true
+		}
 		k.metricsMap[m.Name].LabelKeys = append(k.metricsMap[m.Name].LabelKeys, key)
 		k.metricsMap[m.Name].LabelPath = append(k.metricsMap[m.Name].LabelPath, path)
+	}
+
+	if m.Properties.FieldSelector != "" {
+		k.metricsMap[m.Name].FieldSelector, err = fields.ParseSelector(m.Properties.FieldSelector)
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.Properties.LabelSelector != "" {
+		k.metricsMap[m.Name].LabelSelector, err = labels.Parse(m.Properties.LabelSelector)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isKeyPresent {
+		// Move the "key" label to the end.
+		// It becomes easier to manipulate label values.
+		for i, path := range k.metricsMap[m.Name].LabelPath {
+			temp := k.metricsMap[m.Name].LabelPath
+			temp2 := k.metricsMap[m.Name].LabelKeys
+
+			if strings.HasPrefix(path, "key") {
+				tempKey := temp2[i]
+				temp = append(temp[:i], temp[i+1:]...)
+				temp = append(temp, path)
+
+				temp2 = append(temp2[:i], temp2[i+1:]...)
+				temp2 = append(temp2, tempKey)
+			}
+			k.metricsMap[m.Name].LabelPath = temp
+			k.metricsMap[m.Name].LabelKeys = temp2
+		}
 	}
 
 	return nil
@@ -46,21 +92,24 @@ func (k *kMetrics) LabelNames(metric string) []string {
 }
 
 func (k *kMetrics) Update() error {
-	var err error
 
 	// Clear existing cr list.
 	k.crMap = make(map[string]unstructured.UnstructuredList)
 	for key, val := range k.metricsMap {
-		v, _ := getGVK(val.Obj)
+		v, err := getGVK(val.Obj)
+		if err != nil {
+			log.Error(err)
+			continue
+		}
 
 		// Check if the object related to this GVK has been scraped before.
 		if _, ok := k.crMap[v.Kind]; !ok {
 			u := unstructured.UnstructuredList{}
 			u.SetGroupVersionKind(v)
-			// TODO: add label selector.
-			err = cl.List(context.Background(), &u, &client.ListOptions{Namespace: ""})
+
+			err = cl.List(context.Background(), &u, &client.ListOptions{Namespace: "", FieldSelector: val.FieldSelector, LabelSelector: val.LabelSelector})
 			if err != nil {
-				fmt.Println(err.Error())
+				log.Error(err.Error())
 				continue
 			}
 			// Save the CRs in map.
@@ -99,27 +148,91 @@ func (k *kMetrics) Values(metric string) (Result, error) {
 
 	// Iterate over the Data associated with the metric value.
 	for _, val := range k.metricsMap[metric].Data {
-		// Resolve the Value.
-		v, err := ajson.Eval(val, k.metricsMap[metric].Path)
-		if err != nil {
-			log.Info(err.Error())
-			continue
+
+		//  Handle "val" and "key" keyword.
+		if strings.HasPrefix(k.metricsMap[metric].Path, "val") {
+
+			temp := k.metricsMap[metric].Path
+			path := temp[4 : len(temp)-1]
+
+			v, err := ajson.Eval(val, path)
+			if err != nil {
+				log.Info(err.Error())
+				continue
+			}
+
+			vMap, err := v.Unpack()
+			if err != nil {
+				log.Info(err.Error())
+				continue
+			}
+
+			// Try to coerce it to map[string]interface{} (interface because value can be anything.)
+			if _, ok := vMap.(map[string]interface{}); ok {
+
+				for _, vVal := range vMap.(map[string]interface{}) {
+					res.Vals = append(res.Vals, vVal)
+				}
+			}
+
+		} else {
+			// Resolve the Value.
+			v, err := ajson.Eval(val, k.metricsMap[metric].Path)
+			if err != nil {
+				log.Info(err.Error())
+				continue
+			}
+			result, err := v.Value()
+			if err != nil {
+				log.Info(err.Error())
+				continue
+			}
+			res.Vals = append(res.Vals, result)
 		}
-		result, err := v.Value()
-		if err != nil {
-			log.Info(err.Error())
-			continue
-		}
-		res.Vals = append(res.Vals, result)
 
 		lValues := []string{}
+
+		// Flag to check if we have key or val
+		// in the metric
+		flag := false
 		// Iterate over the label paths of the metric to resolve
 		for _, lPath := range k.metricsMap[metric].LabelPath {
+
+			// Handle "key" keyword.
+			if strings.HasPrefix(lPath, "key") {
+				// i = index
+				path := lPath[4 : len(lPath)-1]
+
+				v, err := ajson.Eval(val, path)
+				if err != nil {
+					log.Info(err.Error())
+					continue
+				}
+
+				vMap, err := v.Unpack()
+				if err != nil {
+					log.Info(err.Error())
+					continue
+				}
+
+				// Try to coerce it to map[string]interface{} (interface because value can be anything.)
+				if _, ok := vMap.(map[string]interface{}); ok {
+					temp := []string{}
+					for key, _ := range vMap.(map[string]interface{}) {
+						flag = true
+						temp = append(lValues, key)
+						res.LabelValues = append(res.LabelValues, temp)
+					}
+				}
+				continue
+			}
+
 			// This helps us in setting constant labels.
 			if lPath[0] != '$' {
 				lValues = append(lValues, lPath)
 				continue
 			}
+
 			// Resolve the Value.
 			v, err := ajson.Eval(val, lPath)
 			if err != nil {
@@ -138,7 +251,12 @@ func (k *kMetrics) Values(metric string) (Result, error) {
 			}
 
 		}
-		res.LabelValues = append(res.LabelValues, lValues)
+		// If labels have been modified by the internal loop
+		// avoid appending lableValues as labels has been taken care of.
+		if !flag {
+			res.LabelValues = append(res.LabelValues, lValues)
+		}
+
 	}
 
 	return res, nil

--- a/pkg/k8sresourcemetrics/metrics_config.go
+++ b/pkg/k8sresourcemetrics/metrics_config.go
@@ -31,11 +31,14 @@ type MetricsConfig struct {
 	Help       string `yaml:"help"`
 	MetricType string `yaml:"type"`
 	Properties struct {
-		PropertyType string            `yaml:"type"`
-		Object       string            `yaml:"object"`
-		Value        string            `yaml:"value"`
-		Unit         string            `yaml:"unit"`
-		Labels       map[string]string `yaml:"labels"`
+		PropertyType  string            `yaml:"type"`
+		Object        string            `yaml:"object"`
+		FieldSelector string            `yaml:"fieldSelector"`
+		LabelSelector string            `yaml:"labelSelector"`
+		Namespace     string            `yaml:"namespace"`
+		Value         string            `yaml:"value"`
+		Unit          string            `yaml:"unit"`
+		Labels        map[string]string `yaml:"labels"`
 	} `yaml:"properties"`
 }
 

--- a/pkg/k8sresourcemetrics/units.go
+++ b/pkg/k8sresourcemetrics/units.go
@@ -79,9 +79,9 @@ func CoerceToFloat64(val interface{}) (float64, error) {
 	case string:
 		valStr := strings.ToLower(t)
 
-		if valStr == "true" || valStr == "ready" {
+		if valStr == "true" || valStr == "ready" || valStr == "active" {
 			valStr = "1.0"
-		} else if valStr == "false" || valStr == "notready" {
+		} else if valStr == "false" || valStr == "notready" || valStr == "inactive" {
 			valStr = "0.0"
 		}
 		return strconv.ParseFloat(valStr, 64)

--- a/resconfig/res.yaml
+++ b/resconfig/res.yaml
@@ -19,3 +19,15 @@ metrics:
     labels:
       name: $.metadata.name
       foo: bar
+- name: config_data_metric
+  help: get the object and its status as metric
+  type: gauge
+  properties:
+    type: kubernetes
+    object: ConfigMap
+    #fieldSelector: metadata.name=your-cm
+    #labelSelector: test=cm
+    value: val($.data)
+    labels:
+      zone: key($.data)
+      name: $.metadata.name 


### PR DESCRIPTION
Lets consider you have object and its status within your CR or Resource.

Eg

```
{
    "apiVersion": "v1",
    "data": {
        "us-east1-b": "active",
        "us-east1-c": "active",
        "us-east1-d": "active"
    },
    "kind": "ConfigMap",
    "metadata": {
        "labels": {
            "test": "cm"
        },
        "name": "***-ha-***",
        "namespace": "**-***k",
        
    }
}
```

Then by adding `key` and `val` keywords respectively you will be able to convert that object to metric.
Eg.

```
- name: zone_health
  help: Current health of Zones
  type: gauge
  properties:
    type: kubernetes
    object: ConfigMap
    #fieldSelector: metadata.name=***-ha-***
    #labelSelector: test=cm
    value: val($.data)
    labels:
      zone: key($.data)
      name: $.metadata.name 
```


Result

```
# HELP quark_health_zone_health Current health of Zones
# TYPE quark_health_zone_health gauge
zone_health{name="***-ha-***",zone="us-east1-b"} 1
zone_health{name="***-ha-***",zone="us-east1-c"} 1
zone_health{name="***-ha-***",zone="us-east1-d"} 1
```